### PR TITLE
fix OBO example method name typo in README

### DIFF
--- a/packages/oauth-entra-id/README.md
+++ b/packages/oauth-entra-id/README.md
@@ -552,7 +552,7 @@ Returns:
 app.post('/on-behalf-of', protectRoute, async (c) => {
   const { services } = await c.req.json();
   const accessToken = c.get('userInfo').accessToken;
-  const { results } = await oauthProvider.getOnBehalfOfToken({ accessToken, services });
+  const { results } = await oauthProvider.getTokenOnBehalfOf({ accessToken, services });
 
   for (const { accessToken } of results) {
     setCookie(c, accessToken.name, accessToken.value, accessToken.options);


### PR DESCRIPTION
Spotted while reading the docs. the OBO code example calls `oauthProvider.getOnBehalfOfToken(...)` but the actual method is `getTokenOnBehalfOf` (word order flipped). So it's just a typo inside the example block. Hopefully I can save some time for the next person who tries to copy paste lol